### PR TITLE
addRemoteTrack: Remove complete pendingTransceivers.

### DIFF
--- a/lib/src/peer_connection.dart
+++ b/lib/src/peer_connection.dart
@@ -435,13 +435,11 @@ class PeerConnection extends EventEmitter {
     peer.onTrack = (event) async {
       _logger.i('New track from peer.');
       _logger.d('Track event value: $event');
-
-      // ignore: lines_longer_than_80_chars
-      // Listen for remote tracks events for resolving pending addRemoteTrack calls.
+      // Listen for remote track events to resolve pending addRemoteTrack calls.
       if (event.transceiver != null && event.streams.isEmpty) {
         if (pendingTransceivers.isNotEmpty) {
           RTCRtpTransceiverCompleter transceiverCompleter =
-              pendingTransceivers.last;
+              pendingTransceivers.removeLast();
           transceiverCompleter.completeTransceiver(event.transceiver!);
         }
       }

--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -135,15 +135,40 @@ class View extends BaseWebRTC {
   /// [List<MediaStream>] streams - Streams the track will belong to.
   /// Return [Future<RTCRtpTransceiver>] Future that will be resolved when the
   /// RTCRtpTransceiver is assigned an mid value.
-
+  ///
+  /// Note: For Android, when adding both Audio & Video tracks, you must add
+  /// Audio tracks first. If you add Video Tracks first,
+  /// your transceiver will get disposed.
+  ///
+  /// @example
+  /// ```dart
+  /// import 'package:flutter_webrtc/flutter_webrtc.dart';
+  /// import 'package:millicast_flutter_sdk/millicast_flutter_sdk.dart';
+  ///
+  /// // ... initialize connection and renderers using view object
+  /// // ...
+  /// MediaStream stream = await createLocalMediaStream('myStream');
+  /// RTCRtpTransceiver transceiver1 = await view!
+  ///     .addRemoteTrack(RTCRtpMediaType.RTCRtpMediaTypeAudio, [stream]);
+  /// RTCRtpTransceiver transceiver = await view!
+  ///     .addRemoteTrack(RTCRtpMediaType.RTCRtpMediaTypeVideo, [stream]);
+  /// await view!.project('mySourceId', [
+  ///   {'trackId': 'audio', 'mediaId': transceiver1.mid}
+  /// ]);
+  /// await view!.project('pip', [
+  ///   {'trackId': 'video', 'mediaId': transceiver.mid}
+  /// ]);
+  ///
+  /// stream.addTrack(transceiver1.receiver.track!);
+  /// stream.addTrack(transceiver.receiver.track!);
+  /// _localRenderer.srcObject = stream;
+  /// // ...
+  /// ```
   Future<RTCRtpTransceiver> addRemoteTrack(
       RTCRtpMediaType media, List<MediaStream> streams) async {
     _logger.i('Viewer adding remote  track $media');
     RTCRtpTransceiver transceiverLocal =
         await webRTCPeer.addRemoteTrack(media, streams);
-    for (var stream in streams) {
-      stream.addTrack(transceiverLocal.receiver.track!);
-    }
     return transceiverLocal;
   }
 


### PR DESCRIPTION
Fix MediaStreamTrack when adding both remote audio/video tracks to the same stream.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### New Feature Submissions:

- [x] Does your submission pass tests?
- [x] Have you lint your code locally prior to submission?

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have verified the pub score with my changes
